### PR TITLE
remove the version string from EE7 EJB JAR file name

### DIFF
--- a/clusterbench-ee7-ear/pom.xml
+++ b/clusterbench-ee7-ear/pom.xml
@@ -53,6 +53,7 @@
                 <configuration>
                     <version>7</version>
                     <defaultLibBundleDir>lib</defaultLibBundleDir>
+                    <fileNameMapping>no-version</fileNameMapping>
                     <modules>
                         <ejbModule>
                             <groupId>org.jboss.test</groupId>


### PR DESCRIPTION
The EE5 and EE6 EJB JARs don't have the version string in their file names
and it's a convention we tend to like. Let's make the EE7 EJB JAR consistent.
