### PR TITLE
remove the "granular" link from index.html in EE7 passivating WAR

### DIFF
--- a/clusterbench-ee7-web/src/main/webapp-passivating/index.html
+++ b/clusterbench-ee7-web/src/main/webapp-passivating/index.html
@@ -31,7 +31,6 @@
             <li><strong>JsfManagedBean</strong> <a href="faces/jsfmanaged.xhtml">/faces/jsfmanaged.xhtml</a></li>
             <li><strong>CdiServlet</strong> <a href="cdi">/cdi</a></li>
             <li><strong>LocalEjbServlet</strong> <a href="ejbservlet">/ejbservlet</a></li>
-            <li><strong>GranularSessionServlet</strong> <a href="granular">/granular</a></li>
             <li><strong>HttpSessionServlet</strong> <a href="session">/session</a></li>
             <li><strong>AverageSystemLoadServlet</strong> <a href="averagesystemload?milliseconds=20000&threads=4">/averagesystemload?milliseconds=20000&threads=4</a></li>
             <li><strong>DebugServlet</strong> <a href="debug">/debug</a></li>


### PR DESCRIPTION
This WAR is assembled without the "granular" stuff, as seen in ee7-web pom.xml. The link doesn't make sense.