### PR TITLE
Investigates default caches contents. Suitable for SMALL, debuggable …

### DIFF
--- a/clusterbench-ee7-web/src/main/java/org/jboss/test/clusterbench/web/debug/DebugServlet.java
+++ b/clusterbench-ee7-web/src/main/java/org/jboss/test/clusterbench/web/debug/DebugServlet.java
@@ -47,6 +47,12 @@ public class DebugServlet extends AbstractCommonDebugServlet {
         // Get current cache nodes
         info.append("Members: ").append(container.getMembers()).append(System.getProperty("line.separator"));
 
+        // This WILL OOM your server instance if you have hundreds of thousands of REPL values. Even sooner with DIST.
+        for (String cacheName : container.getCacheNames()) {
+            info.append("Cache: ").append(cacheName).append(", Size: ").append(container.getCache(cacheName).size()).append(System.getProperty("line.separator"));
+            info.append("\tKeys: ").append(container.getCache(cacheName).keySet()).append(System.getProperty("line.separator"));
+        }
+
         info.append("Physical addresses: ");
         JGroupsTransport transport = (JGroupsTransport) container.getTransport();
         for (Address infinispanWrapAddr : container.getMembers()) {


### PR DESCRIPTION
…volumes.

The methods used, i.e. keySet and size are utterly unusable for large caches, so if anybody uses debug servlet for dozens to hundreds of thousands of records, it will OOM the server. If it is the case, I'll amend the commit with some URL query param to switch the new function on/off.
# Example output

```
karm@localhost:~/Projects/MOD_CLUSTER/httpd-2.4.20-build/bin$ curl -c cookie.txt -b cookie.txt http://127.0.0.1:8080/clusterbench/debug
Serial: 22
Session ID: Ok6CfU2Az90jOVLJE_NkXPpBwDwq6YP5EwlbD5X-
Current time: Tue May 31 11:25:25 CEST 2016
ServletRequest.getServerPort(): 8080
ServletRequest.getLocalPort(): 8080
Node name: localhost
Members: [localhost]
Cache: clusterbench-ee7.ear.clusterbench-ee7-web-passivating.war, Size: 0
    Keys: []
Cache: routing, Size: 1
    Keys: [localhost]
Cache: clusterbench-ee7.ear.clusterbench-ee7-web-granular.war, Size: 0
    Keys: []
Cache: clusterbench-ee7.ear.clusterbench-ee7-web-default.war, Size: 3
    Keys: [Ok6CfU2Az90jOVLJE_NkXPpBwDwq6YP5EwlbD5X-, Ok6CfU2Az90jOVLJE_NkXPpBwDwq6YP5EwlbD5X-, Ok6CfU2Az90jOVLJE_NkXPpBwDwq6YP5EwlbD5X-]
Cache: dist, Size: 0
    Keys: []
Physical addresses: 127.0.0.1:55200;
```
