### PR TITLE
added configurable cargo for http session

### DIFF
--- a/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/ClusterBenchConstants.java
+++ b/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/ClusterBenchConstants.java
@@ -21,4 +21,6 @@ public interface ClusterBenchConstants {
     String READONLY = "readonly";
 
     String INVALIDATE = "invalidate";
+
+    String CARGOKB = "cargokb";
 }

--- a/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/SerialBean.java
+++ b/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/SerialBean.java
@@ -23,10 +23,15 @@ public class SerialBean implements Serializable {
 
     private int serial;
     private byte[] cargo;
+    public static final int DEFAULT_CARGOKB = 4;
 
     public SerialBean() {
+        this(DEFAULT_CARGOKB);
+    }
+
+    public SerialBean(int cargokb) {
         this.serial = 0;
-        this.cargo = new byte[4 * 1024];
+        this.cargo = new byte[cargokb * 1024];
         Random rand = new Random();
         rand.nextBytes(cargo);
     }

--- a/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/session/CommonHttpSessionServlet.java
+++ b/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/session/CommonHttpSessionServlet.java
@@ -38,8 +38,14 @@ public class CommonHttpSessionServlet extends HttpServlet {
         HttpSession session = req.getSession(true);
 
         if (session.isNew()) {
-            log.log(Level.INFO, "New session created: {0}", session.getId());
-            session.setAttribute(KEY, this.createSerialBean());
+            if (req.getParameter(ClusterBenchConstants.CARGOKB) != null && req.getParameter(ClusterBenchConstants.CARGOKB).matches("[0-9]+")) {
+                log.log(Level.INFO, "New session created: {0} with {1}kB cargo", new Object[]{session.getId(), req.getParameter(ClusterBenchConstants.CARGOKB)});
+                int kargokb = Integer.parseInt(req.getParameter(ClusterBenchConstants.CARGOKB));
+                session.setAttribute(KEY, this.createSerialBean(kargokb));
+            } else {
+                log.log(Level.INFO, "New session created: {0} with {1}kB cargo", new Object[]{session.getId(), SerialBean.DEFAULT_CARGOKB});
+                session.setAttribute(KEY, this.createSerialBean());
+            }
         } else if (session.getAttribute(KEY) == null) {
             log.log(Level.INFO, "Session is not new, creating SerialBean: {0}", session.getId());
             session.setAttribute(KEY, this.createSerialBean());
@@ -68,6 +74,10 @@ public class CommonHttpSessionServlet extends HttpServlet {
             log.log(Level.INFO, "Invalidating: {0}", session.getId());
             session.invalidate();
         }
+    }
+
+    private Object createSerialBean(int cargokbytes) {
+        return new SerialBean(cargokbytes);
     }
 
     protected Object createSerialBean() {


### PR DESCRIPTION
Added configurable cargo for http session via an optional query parameter; e.g.:
`http//<host>:8080/clusterbench/session?cargokb=40 `
means 40kb cargo (default is 4kb)