### PR TITLE
Expanded patterns on debug and session, added more info to debug

### DIFF
--- a/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/debug/AbstractCommonDebugServlet.java
+++ b/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/debug/AbstractCommonDebugServlet.java
@@ -18,6 +18,8 @@ package org.jboss.test.clusterbench.common.debug;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -25,7 +27,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -48,6 +49,8 @@ public abstract class AbstractCommonDebugServlet extends HttpServlet {
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
         HttpSession session = req.getSession(true);
+        resp.setContentType("text/plain");
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
         PrintWriter out = resp.getWriter();
 
         if (session.isNew()) {
@@ -84,6 +87,13 @@ public abstract class AbstractCommonDebugServlet extends HttpServlet {
 
         // Request URI
         out.println("Request URI: " + req.getRequestURI());
+        // Query path of the URL
+        out.println("Query string: " + req.getQueryString());
+        // Query path of the URL decoded
+        out.println("Query string UTF-8 decoded: " + ((req.getQueryString() == null) ? "null" :
+                                                    URLDecoder.decode(req.getQueryString(), StandardCharsets.UTF_8)));
+        // Extra path information
+        out.println("Path info: " + req.getPathInfo());
         // Common debug info
         out.println("Serial: " + serial);
         // Get the session ID with the route (if present)

--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/debug/DebugServlet.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/debug/DebugServlet.java
@@ -31,7 +31,7 @@ import org.jgroups.stack.IpAddress;
 /**
  * @author Radoslav Husar
  */
-@WebServlet(name = "DebugServlet", urlPatterns = { "/debug" })
+@WebServlet(name = "DebugServlet", urlPatterns = { "/debug", "/debug/*" })
 public class DebugServlet extends AbstractCommonDebugServlet {
 
     @Resource(lookup = "java:jboss/infinispan/container/web")

--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/session/HttpSessionServlet.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/session/HttpSessionServlet.java
@@ -23,7 +23,7 @@ import jakarta.servlet.annotation.WebServlet;
 /**
  * @author Radoslav Husar
  */
-@WebServlet(name = "HttpSessionServlet", urlPatterns = { "/session" })
+@WebServlet(name = "HttpSessionServlet", urlPatterns = { "/session", "/session/*" })
 public class HttpSessionServlet extends CommonHttpSessionServlet {
 
     @Override


### PR DESCRIPTION
Added `<path>/*` patterns to session and debug to allow testing URL context delimiters in clustered environment

Added extra path info and query string output to debug servlet for the same reason.