### PR TITLE
Workaround for FD_SOCK2 failing on resource service restart on Window…

### DIFF
--- a/clusterbench-ee10-ear/pom.xml
+++ b/clusterbench-ee10-ear/pom.xml
@@ -165,7 +165,19 @@
                         <artifactId>wildfly-maven-plugin</artifactId>
                         <configuration>
                             <server-args>
-                                <server-arg>--server-config=standalone-full-ha.xml</server-arg>
+                                <!--
+                                FIXME workaround for FD_SOCK2 failing on resource service restart on Windows platform - switch to ha profile from full-ha which starts the channel on demand
+
+                                2023-07-25T08:21:28.7711991Z Caused by: java.lang.IllegalStateException: clusterbench-1: failed to find an available port in ports [54200, 54201, 54202, 54203]
+                                ...
+                                2023-07-25T08:21:29.3791333Z [INFO] [standalone@embedded /] batch
+                                2023-07-25T08:21:30.0202882Z [INFO] [standalone@embedded / #] /subsystem=jgroups/stack=udp/protocol=FD_SOCK2:write-attribute(name=properties,value={port_range=100})
+                                2023-07-25T08:21:30.0266081Z [INFO] [standalone@embedded / #] run-batch &#45;&#45;headers={allow-resource-service-restart=true}
+                                ...
+                                2023-07-25T08:21:31.1781113Z Caused by: java.lang.Exception: failed to open a port in range 55200-55200 (last exception: java.net.BindException: Address already in use: Cannot bind)
+                                -->
+                                <!-- <server-arg>&#45;&#45;server-config=standalone-full-ha.xml</server-arg>-->
+                                <server-arg>--server-config=standalone-ha.xml</server-arg>
                                 <server-arg>-Djboss.node.name=clusterbench-1</server-arg>
                             </server-args>
                         </configuration>


### PR DESCRIPTION
…s platform

e.g. https://pipelines.actions.githubusercontent.com/serviceHosts/6d0b5d63-4385-4256-b824-1ca3d1c5d4a0/_apis/pipelines/1/runs/485/signedlogcontent/7?urlExpires=2023-07-31T16%3A49%3A01.2039270Z&urlSigningMethod=HMACV1&urlSignature=y8FB%2BxO%2F2fKsbQNjOKgHLMrGglNiAIZ%2Be1xb3fKiCBE%3D