### PR TITLE
Add workaround for WFLY-18727 ATTRIBUTE granularity distributed sessi…

### DIFF
--- a/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/session/CommonHttpSessionServlet.java
+++ b/clusterbench-common/src/main/java/org/jboss/test/clusterbench/common/session/CommonHttpSessionServlet.java
@@ -54,7 +54,8 @@ public class CommonHttpSessionServlet extends HttpServlet {
         bean.setSerial(serial + 1);
 
         // Now store bean in the session
-        session.setAttribute(KEY, bean);
+        // Workaround for "WFLY-18727 ATTRIBUTE granularity distributed sessions should always replicate on setAttribute(...)" by wrapping into a new object instance.
+        session.setAttribute(KEY, this.wrapSerialBean(bean));
 
         resp.getWriter().print(serial);
 
@@ -71,6 +72,11 @@ public class CommonHttpSessionServlet extends HttpServlet {
 
     protected Object createSerialBean() {
         return new SerialBean();
+    }
+
+    // n.b. all of the CommonHttpSessionServlet will be removed from the common module.
+    protected Object wrapSerialBean(SerialBean serialBean) {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/session/HttpSessionServlet.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/session/HttpSessionServlet.java
@@ -5,6 +5,7 @@
 
 package org.jboss.test.clusterbench.web.session;
 
+import org.jboss.test.clusterbench.common.SerialBean;
 import org.jboss.test.clusterbench.common.session.CommonHttpSessionServlet;
 
 import jakarta.servlet.annotation.WebServlet;
@@ -18,5 +19,13 @@ public class HttpSessionServlet extends CommonHttpSessionServlet {
     @Override
     protected Object createSerialBean() {
         return new ImmutableSerialBean();
+    }
+
+    @Override
+    protected Object wrapSerialBean(SerialBean serialBean) {
+        SerialBean wrapper = new ImmutableSerialBean();
+        wrapper.setSerial(serialBean.getSerial());
+        wrapper.setCargo(serialBean.getCargo());
+        return wrapper;
     }
 }


### PR DESCRIPTION
…ons should always replicate on setAttribute(...) #393

Jira: https://issues.redhat.com/browse/WFLY-18727

Fix Version/s:
[31.0.0.Beta1](https://issues.redhat.com/issues/?jql=project+%3D+WFLY+AND+fixVersion+%3D+31.0.0.Beta1), [30.0.1.Final](https://issues.redhat.com/issues/?jql=project+%3D+WFLY+AND+fixVersion+%3D+30.0.1.Final)