### PR TITLE
Add LoggerServlet

### DIFF
--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/debug/LoggerServlet.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/debug/LoggerServlet.java
@@ -1,0 +1,25 @@
+package org.jboss.test.clusterbench.web.debug;
+
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+@WebServlet("/log")
+public class LoggerServlet extends HttpServlet {
+	private static final Logger LOG = Logger.getLogger(LoggerServlet.class.getCanonicalName());
+
+	private void logMarker(String msg) {
+		LOG.info(msg);
+	}
+
+	public void doGet(HttpServletRequest request, HttpServletResponse response)
+			throws IOException {
+		String msg = request.getParameter("msg");
+		logMarker(msg);
+		response.getWriter().print("Success");
+	}
+}

--- a/integration-tests/wildfly/src/test/java/org/jboss/test/clusterbench/it/wildfly/LoggerServletIT.java
+++ b/integration-tests/wildfly/src/test/java/org/jboss/test/clusterbench/it/wildfly/LoggerServletIT.java
@@ -1,0 +1,33 @@
+package org.jboss.test.clusterbench.it.wildfly;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(ArquillianExtension.class)
+@RunAsClient
+public class LoggerServletIT extends AbstractWildFlyIT {
+	/**
+	 * Verifies log servlet is deployed
+	 */
+	@Test
+	public void test() throws Exception {
+		try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
+			HttpGet httpGet = new HttpGet("http://localhost:8080/clusterbench/log");
+			try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+				assertEquals(200, response.getStatusLine().getStatusCode());
+				String responseBody = EntityUtils.toString(response.getEntity());
+				assertEquals("Success", responseBody);
+			}
+		}
+
+	}
+}


### PR DESCRIPTION
Add a simple servlet named `LoggerServlet` which just prints a customized message in the server.log file, e.g.:
```
2024-11-13 16:05:00,158 INFO  [org.jboss.test.clusterbench.web.debug.LoggerServlet] (default task-1) CLUSTERING_LIFECYCLE_MARKER: ping
```