### PR TITLE
Revert "Add workaround for WFLY-18727 ATTRIBUTE granularity distribut…

### DIFF
--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/common/session/CommonHttpSessionServlet.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/common/session/CommonHttpSessionServlet.java
@@ -54,8 +54,7 @@ public class CommonHttpSessionServlet extends HttpServlet {
         bean.setSerial(serial + 1);
 
         // Now store bean in the session
-        // Workaround for "WFLY-18727 ATTRIBUTE granularity distributed sessions should always replicate on setAttribute(...)" by wrapping into a new object instance.
-        session.setAttribute(KEY, this.wrapSerialBean(bean));
+        session.setAttribute(KEY, bean);
 
         resp.getWriter().print(serial);
 
@@ -72,11 +71,6 @@ public class CommonHttpSessionServlet extends HttpServlet {
 
     protected Object createSerialBean() {
         return new SerialBean();
-    }
-
-    // n.b. all of the CommonHttpSessionServlet will be removed from the common module.
-    protected Object wrapSerialBean(SerialBean serialBean) {
-        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/session/HttpSessionServlet.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/web/session/HttpSessionServlet.java
@@ -5,7 +5,6 @@
 
 package org.jboss.test.clusterbench.web.session;
 
-import org.jboss.test.clusterbench.common.SerialBean;
 import org.jboss.test.clusterbench.common.session.CommonHttpSessionServlet;
 
 import jakarta.servlet.annotation.WebServlet;
@@ -19,13 +18,5 @@ public class HttpSessionServlet extends CommonHttpSessionServlet {
     @Override
     protected Object createSerialBean() {
         return new ImmutableSerialBean();
-    }
-
-    @Override
-    protected Object wrapSerialBean(SerialBean serialBean) {
-        SerialBean wrapper = new ImmutableSerialBean();
-        wrapper.setSerial(serialBean.getSerial());
-        wrapper.setCargo(serialBean.getCargo());
-        return wrapper;
     }
 }


### PR DESCRIPTION
…ed sessions should always replicate on setAttribute(...) #393"

This reverts commit 936e2184bde168180578e7eb8a190980147b0a49.

Remove workaround for https://issues.redhat.com/browse/WFLY-18727. No longer needed since [30.0.1.Final](https://issues.redhat.com/issues/?jql=project+%3D+WFLY+AND+fixVersion+%3D+30.0.1.Final), [31.0.0.Beta1](https://issues.redhat.com/issues/?jql=project+%3D+WFLY+AND+fixVersion+%3D+31.0.0.Beta1), [31.0.0.Final](https://issues.redhat.com/issues/?jql=project+%3D+WFLY+AND+fixVersion+%3D+31.0.0.Final).