### PR TITLE
build(deps): Bump version.org.wildfly from 38.0.0.Final to 38.0.1.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
         <maven.compiler.source>17</maven.compiler.source>
 
         <!-- WildFly components versions -->
-        <version.org.wildfly>38.0.0.Final</version.org.wildfly>
+        <version.org.wildfly>38.0.1.Final</version.org.wildfly>
         <version.org.wildfly.cloud-feature-pack>8.1.0.Final</version.org.wildfly.cloud-feature-pack>
         <version.org.wildfly.maven.plugin>5.1.5.Final</version.org.wildfly.maven.plugin>
 


### PR DESCRIPTION
Bumps `version.org.wildfly` from 38.0.0.Final to 38.0.1.Final.

Updates `org.wildfly.bom:wildfly-ee-with-tools` from 38.0.0.Final to 38.0.1.Final

Updates `org.wildfly:wildfly-clustering-web-api` from 38.0.0.Final to 38.0.1.Final

---
updated-dependencies:
- dependency-name: org.wildfly.bom:wildfly-ee-with-tools dependency-version: 38.0.1.Final dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: org.wildfly:wildfly-clustering-web-api dependency-version: 38.0.1.Final dependency-type: direct:production update-type: version-update:semver-patch ...