### PR TITLE
Fix for Inner class could be static

### DIFF
--- a/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/common/load/AverageSystemLoad.java
+++ b/clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/common/load/AverageSystemLoad.java
@@ -47,7 +47,7 @@ public class AverageSystemLoad {
         return stillActiveRunners;
     }
 
-    private class LoadRunner implements Runnable {
+    private static class LoadRunner implements Runnable {
 
         private int milliseconds;
         private boolean isComplete = false;


### PR DESCRIPTION
General fix: convert nested classes that do not use instance state of the enclosing class into `static` nested classes.

Best fix here: in `clusterbench-ee10-web/src/main/java/org/jboss/test/clusterbench/common/load/AverageSystemLoad.java`, change `LoadRunner` from a non-static inner class to a static nested class by updating its declaration from `private class LoadRunner` to `private static class LoadRunner`. No other logic changes are required because `LoadRunner` already operates only on its own fields and does not reference `AverageSystemLoad.this`. No new imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._