### PR TITLE
feat: add Tomcat Containerfile and parametrize CI workflow

### DIFF
--- a/.github/workflows/containerfile.yml
+++ b/.github/workflows/containerfile.yml
@@ -18,6 +18,12 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        runtime:
+          - wildfly
+          - tomcat
+
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -29,32 +35,32 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          file: ./Containerfile
+          file: ./Containerfile.${{ matrix.runtime }}
           push: false
           load: true
-          tags: clusterbench-ee11:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          tags: clusterbench-${{ matrix.runtime }}
+          cache-from: type=gha,scope=${{ matrix.runtime }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.runtime }}
 
       - name: Start container
         run: |
-          docker run -d --name clusterbench-ee11-test -p 8080:8080 clusterbench-ee11:test
+          echo "CONTAINER_ID=$(docker run -d -p 8080:8080 clusterbench-${{ matrix.runtime }})" >> "$GITHUB_ENV"
 
-      - name: Wait for WildFly to start
+      - name: Wait for server to start
         run: |
-          echo "Waiting for WildFly to be ready..."
+          echo "Waiting for ${{ matrix.runtime }} to be ready..."
           timeout=120
           elapsed=0
           while [ $elapsed -lt $timeout ]; do
             if curl -f -s http://localhost:8080/clusterbench/ > /dev/null 2>&1; then
-              echo "WildFly is ready!"
+              echo "${{ matrix.runtime }} is ready!"
               exit 0
             fi
             echo "Waiting... ($elapsed/$timeout seconds)"
             sleep 5
             elapsed=$((elapsed + 5))
           done
-          echo "Timeout waiting for WildFly to start"
+          echo "Timeout waiting for ${{ matrix.runtime }} to start"
           exit 1
 
       - name: Test application response
@@ -81,4 +87,4 @@ jobs:
         if: failure()
         run: |
           echo "Container logs:"
-          docker logs clusterbench-ee11-test || true
+          docker logs "$CONTAINER_ID" || true

--- a/Containerfile.tomcat
+++ b/Containerfile.tomcat
@@ -1,0 +1,28 @@
+# Build stage
+FROM eclipse-temurin:25 AS build
+
+WORKDIR /build
+
+# Install unzip required by Maven Wrapper to download the .zip distribution;
+# without it, mvnw downloads .tar.gz which doesn't match distributionSha256Sum
+RUN apt-get update && apt-get install -y unzip
+
+# Copy entire source code
+COPY . .
+
+# Build only the deployment archive and its dependencies
+RUN ./mvnw clean install --batch-mode --no-transfer-progress --define skipTests --projects clusterbench-ee11-web --also-make
+
+# Runtime stage
+# https://hub.docker.com/_/tomcat
+FROM tomcat:11.0-jdk21-temurin-noble
+
+LABEL maintainer="Radoslav Husar <radosoft@gmail.com>"
+
+# Remove default webapps
+RUN rm -rf /usr/local/tomcat/webapps/*
+
+# Copy the Tomcat WAR from build stage
+COPY --from=build /build/clusterbench-ee11-web/target/clusterbench-ee11-web-tomcat.war /usr/local/tomcat/webapps/clusterbench.war
+
+CMD ["catalina.sh", "run"]

--- a/Containerfile.wildfly
+++ b/Containerfile.wildfly
@@ -10,8 +10,8 @@ RUN apt-get update && apt-get install -y unzip
 # Copy entire source code
 COPY . .
 
-# Build only the EE11 EAR and its dependencies
-RUN ./mvnw clean install --batch-mode --no-transfer-progress --define skipTests --projects clusterbench-ee11-ejb,clusterbench-ee11-web,clusterbench-ee11-ear --also-make
+# Build only the deployment archive and its dependencies
+RUN ./mvnw clean install --batch-mode --no-transfer-progress --define skipTests --projects clusterbench-ee11-ear --also-make
 
 # Runtime stage
 # https://quay.io/repository/wildfly/wildfly

--- a/README.adoc
+++ b/README.adoc
@@ -57,20 +57,34 @@ Output files:
 ./clusterbench-ee10-ear/target/clusterbench-ee10.ear
 ----
 
-=== Building Container Image
+=== Building Container Images
 
-To build a container image with Podman:
-
-[source,shell]
-----
-podman build -t clusterbench-ee10 .
-----
-
-To run the container:
+To build a WildFly container image with Podman:
 
 [source,shell]
 ----
-podman run -p 8080:8080 -p 9990:9990 clusterbench-ee10
+podman build -f Containerfile.wildfly -t clusterbench-wildfly .
+----
+
+To run the WildFly container:
+
+[source,shell]
+----
+podman run -p 8080:8080 -p 9990:9990 clusterbench-wildfly
+----
+
+To build a Tomcat container image:
+
+[source,shell]
+----
+podman build -f Containerfile.tomcat -t clusterbench-tomcat .
+----
+
+To run the Tomcat container:
+
+[source,shell]
+----
+podman run -p 8080:8080 clusterbench-tomcat
 ----
 
 and navigate your browser to http://localhost:8080/clusterbench/.


### PR DESCRIPTION
Split the single Containerfile into Containerfile.wildfly and Containerfile.tomcat, and update the CI workflow to use a matrix strategy to build and test both images in parallel.